### PR TITLE
docs: fix README build commands to match current package.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,25 +7,14 @@
 npm install
 
 # serve with hot reload at localhost:8080
-npm run dev
+npm run serve
 
 # build for production with minification
 npm run build
 
-# build for production and view the bundle analyzer report
-npm run build --report
-
-# run unit tests
-npm run unit
-
-# run e2e tests
-npm run e2e
-
-# run all tests
-npm test
+# lint and fix files
+npm run lint
 ```
-
-For detailed explanation on how things work, checkout the [guide](http://vuejs-templates.github.io/webpack/) and [docs for vue-loader](http://vuejs.github.io/vue-loader).
 
 ## Editor setup (Vue 2 + TypeScript)
 


### PR DESCRIPTION
## Summary

- `npm run dev` → `npm run serve` (vue-cli-service の実際のスクリプト名)
- 存在しないコマンド (`unit`, `e2e`, `test`) を削除し、`lint` を追加
- 古い Vue webpack template のガイドリンクを削除

## Test plan

- [ ] README のコマンドをコピペして実行できることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)