### PR TITLE
fix: resolve tsconfig errors for Vue 3 + Vite migration

### DIFF
--- a/src/shims-vue.d.ts
+++ b/src/shims-vue.d.ts
@@ -1,0 +1,5 @@
+declare module '*.vue' {
+  import type { DefineComponent } from 'vue'
+  const component: DefineComponent<object, object, unknown>
+  export default component
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,10 +11,9 @@
     "strictFunctionTypes": false,
     "forceConsistentCasingInFileNames": true,
     "sourceMap": true,
-    "baseUrl": ".",
     "paths": {
       "@/*": [
-        "src/*"
+        "./src/*"
       ]
     },
     "lib": [


### PR DESCRIPTION
## Summary

- `src/shims-vue.d.ts` を新規作成し、`.vue` ファイルの型宣言 (`DefineComponent`) を追加 — `TS7016` エラーを修正
- `tsconfig.json` から非推奨の `baseUrl` を削除（TS 7.0 で廃止予定）
- `paths` のエイリアスを `src/*` → `./src/*` に変更し `baseUrl` なしで解決できるよう対応

## Test plan

- [x] `npx tsc --noEmit` — エラーなし
- [x] `npm run build` — ビルド成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)