### PR TITLE
test: add bes2unicode tests generated via local LLM (Ollama)

### DIFF
--- a/src/modules/bes2unicode.simple.test.ts
+++ b/src/modules/bes2unicode.simple.test.ts
@@ -1,0 +1,53 @@
+// src/modules/bes2unicode.simple.test.ts
+import { describe, it, expect } from 'vitest'
+import bes2unicode from './bes2unicode'
+
+const makeBytes = (...dataBytes: number[]): Uint8Array => {
+  const headerSize = 1029
+  const totalSize = headerSize + dataBytes.length
+  const arr = new Uint8Array(totalSize)
+  for (let i = 0; i < headerSize; i++) {
+    arr[i] = 0
+  }
+  for (let i = 0; i < dataBytes.length; i++) {
+    arr[headerSize + i] = dataBytes[i]
+  }
+  return arr
+}
+
+describe('bes2unicode', () => {
+  it('should return an empty string when only the header bytes are present', () => {
+    const bytes = makeBytes() // Only header bytes
+    expect(bes2unicode(bytes)).toBe('')
+  })
+
+  it('should correctly convert a single 0xa1 byte', () => {
+    const bytes = makeBytes(0xa1)
+    expect(bes2unicode(bytes)).toBe('⠁')
+  })
+
+  it('should correctly convert multiple known bytes [0xa1, 0xa3]', () => {
+    const bytes = makeBytes(0xa1, 0xa3)
+    expect(bes2unicode(bytes)).toBe('⠁⠃')
+  })
+
+  it('should skip unknown bytes (e.g., 0x01)', () => {
+    const bytes = makeBytes(0x01)
+    expect(bes2unicode(bytes)).toBe('')
+  })
+
+  it('should handle a mix of known and unknown bytes [0xa1, 0xfe, 0xa3]', () => {
+    const bytes = makeBytes(0xa1, 0xfe, 0xa3)
+    expect(bes2unicode(bytes)).toBe('⠁@LB@⠃')
+  })
+
+  it('should handle sequence starting with a known byte (e.g., 0x0d)', () => {
+    const bytes = makeBytes(0x0d)
+    expect(bes2unicode(bytes)).toBe('')
+  })
+
+  it('should handle sequence containing a null byte (0x00)', () => {
+    const bytes = makeBytes(0x00)
+    expect(bes2unicode(bytes)).toBe('')
+  })
+})


### PR DESCRIPTION
## Summary

- ローカルLLM（`gemma4:e4b` via `ollama_generate` MCP）を使って生成したユニットテストを追加
- 生成後に必要だった修正は import パスの1箇所のみ

## 生成されたテスト内容

`src/modules/bes2unicode.simple.test.ts`（7テスト）:
- ヘッダーのみ → 空文字列
- 単一バイト `0xa1` → `⠁`
- 複数バイト `[0xa1, 0xa3]` → `⠁⠃`
- 未知バイト `0x01` → スキップ（空文字列）
- 混在 `[0xa1, 0xfe, 0xa3]` → `⠁@LB@⠃`
- `0x0d` → 空文字列
- `0x00` → 空文字列

## Test plan

- [x] `npm test -- --run` で全 33 テストが PASS することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)