### PR TITLE
fix: ファイルを閉じた時にファイル名表示をクリアする

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -10,7 +10,7 @@
           <div class="navbar-start">
             <div class="navbar-item">
               <label for="file">ファイル</label>
-              <input type="file" id="file" name="file" accept=".bes" @change="onFileChange" />
+              <input type="file" id="file" name="file" accept=".bes" @change="onFileChange" ref="fileInput" />
             </div>
             <div class="navbar-item">
               <button class="button is-small is-light" id="closeFile" :disabled="isFileClosed" @click="onFileClose">ファイルを閉じる</button>
@@ -56,6 +56,7 @@ import bes2unicode from './modules/bes2unicode'
 const isYomiChecked = ref(false)
 const openFile = ref(false)
 const str = ref('')
+const fileInput = ref<HTMLInputElement | null>(null)
 
 const bes = computed(() => str.value)
 const isFileClosed = computed(() => !openFile.value)
@@ -82,6 +83,7 @@ const onFileChange = (event: Event) => {
 const onFileClose = () => {
   str.value = ''
   openFile.value = false
+  if (fileInput.value) fileInput.value.value = ''
 }
 
 const onGetBesUrl = (url: string) => {


### PR DESCRIPTION
## Summary

- `<input type="file">` 要素に `ref="fileInput"` を追加
- `onFileClose()` 実行時に `fileInput.value.value = ''` でインプット要素自体をリセット
- これによりブラウザのネイティブファイル名表示が「ファイルを閉じる」と同時にクリアされる

## Background

`onFileClose()` はアプリ状態（`str`、`openFile`）をリセットしていたが、`<input type="file">` 要素はJavaScriptで `.value = ''` を明示的に設定しない限りファイル名を保持し続けるブラウザ仕様があり、前のファイル名が残ったままになっていた。

## Test plan

- [ ] `.bes` ファイルを選択 → ファイル名が表示されること
- [ ] 「ファイルを閉じる」をクリック → ファイル名欄が空になること
- [ ] 再度ファイルを選択できること
- [ ] `npm test -- --run` で全テスト (33件) パスすること

🤖 Generated with [Claude Code](https://claude.com/claude-code)